### PR TITLE
improvements to vertical grid pattern, fix label for show photo/waypoints

### DIFF
--- a/lib/layouts/info.dart
+++ b/lib/layouts/info.dart
@@ -45,7 +45,7 @@ class _InfoState extends State<Info> {
                 });
               }),
           SwitchListTile(
-              title: const Text("Show Waypoints"),
+              title: Text((listenables.createCameraPoints)?"Show Photo Points":"Show Waypoints" ),
               value: listenables.showPoints,
               onChanged: (value) {
                 setState(() {


### PR DESCRIPTION
Attempt to improve 'Fill Grid' optional vertical grid pattern to start closer to the end of the initial horizontal run, and to provide better overlap of the horizontal grid boundary.  Also a minor adjustment to the label in the info tab for show photo/waypoints to dynamically change its title according to use of the Create Photo Points option.