### PR TITLE
Fix breaking change to flutter_map update

### DIFF
--- a/lib/layouts/home.dart
+++ b/lib/layouts/home.dart
@@ -279,7 +279,8 @@ class _HomeLayoutState extends State<HomeLayout> with TickerProviderStateMixin {
                         borderStrokeWidth: 3),
                 ]),
                 PolylineLayer(polylines: [
-                  listenables.flightLine ?? Polyline(points: [])
+                  if(listenables.flightLine != null)
+                    listenables.flightLine ?? Polyline(points: [])
                 ]),
                 if (listenables.showPoints) MarkerLayer(markers: _photoMarkers),
                 DragMarkers(markers: [


### PR DESCRIPTION
Added a null check for flightLine to prevent runtime exception since apparently the flutter_map 8.1.0 update.