### PR TITLE
Add DJI Air 3S camera #47

### DIFF
--- a/lib/presets/preset_manager.dart
+++ b/lib/presets/preset_manager.dart
@@ -76,7 +76,15 @@ class PresetManager {
         sensorHeight: 6.14,
         focalLength: 9.10,
         imageWidth: 640,
-        imageHeight: 512)
+        imageHeight: 512),
+    CameraPreset(
+        name: "DJI Air 3S",
+        defaultPreset: true,
+        sensorWidth: 13.2,
+        sensorHeight: 8.8,
+        focalLength: 24.00,
+        imageWidth: 8192,
+        imageHeight: 6144)
   ];
 
   /// Sets the default presets


### PR DESCRIPTION
Adds the deafaults for DJI Ait 3s 1 inch camera.

https://github.com/YarosMallorca/DJI-Mapper/issues/47