### PR TITLE
Add DJI Mini 2 (12 MP) camera preset

### DIFF
--- a/lib/presets/preset_manager.dart
+++ b/lib/presets/preset_manager.dart
@@ -54,6 +54,14 @@ class PresetManager {
         imageWidth: 8192,
         imageHeight: 6144),
     CameraPreset(
+        name: "DJI Mini 2 (12 MP)",
+        defaultPreset: true,
+        sensorWidth: 6.3,
+        sensorHeight: 4.7,
+        focalLength: 4.49,
+        imageWidth: 4000,
+        imageHeight: 3000),
+    CameraPreset(
         name: "DJI Mini 3 Pro (12 MP)",
         defaultPreset: true,
         sensorWidth: 9.7,


### PR DESCRIPTION
Adds a built-in camera preset for the DJI Mini 2 (original, FC7303).

The Mini 2 is already in the supported aircraft list (via Litchi) but
had no matching camera preset. Users were required to create a custom
entry on every new browser session.

Specs sourced from EXIF metadata and confirmed against photogrammetry
community references:
- Sensor: 1/2.3" CMOS, 6.3 × 4.7 mm
- Focal length: 4.49 mm (actual, not 35mm equivalent)
- Resolution: 4000 × 3000 (12 MP)
- Pixel pitch: 1.55 µm